### PR TITLE
#6 Refactor Makefiles: centralize shared logic and improve target con…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,31 @@
 index_url ?= ''
 DOCKER_DIR_NAME ?= docker
 
+# .PHONY: build-container build-multiplatform push-container stop-container run try-request
+# It's good practice to declare phony targets.
+.PHONY: build-container build-multiplatform push-container stop-container run try-request
+
+# Delegates the 'build' command to the specified project's Makefile.
 build-container:
 	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) build index_url=$(index_url)
 
+# Delegates the 'build-multiplatform' command.
 build-multiplatform:
 	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) build-multiplatform
 
+# Delegates the 'push' command.
+push-container:
+	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) push
+
+# Delegates the 'stop' command.
 stop-container:
-	docker kill $(project) || true
-	docker rm $(project) || true
+	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) stop
 
-
+# Delegates the 'run' command after ensuring the container is built.
 run: build-container
+	@echo "Executing 'run' for project '$(project)'..."
 	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) run
 
+# Delegates the 'try-request' command.
 try-request:
 	$(MAKE) -C ./projects/$(project)/$(DOCKER_DIR_NAME) try-request

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,34 @@
+# This is a common Makefile included by sub-projects.
+# It expects the following variables to be set by the including Makefile:
+#   - EXAMPLE_NAME
+#   - HOST_PORT
+#   - CONTAINER_PORT
+
+DOCKER_ORG ?= ghcr.io/hpp-io
+TAG := $(DOCKER_ORG)/example-$(EXAMPLE_NAME)-noosphere:latest
+CONTAINER_NAME := $(EXAMPLE_NAME)
+
+# Declare all phony targets to prevent conflicts with file names.
+.PHONY: build stop push build-multiplatform
+
+# Builds the Docker image for the project.
+build:
+	@echo "Building Docker image: $(TAG)"
+	@docker build -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile .
+
+# Stops and removes the running container for the project.
+stop:
+	@echo "Stopping and removing container '$(CONTAINER_NAME)'..."
+	@docker stop $(CONTAINER_NAME) > /dev/null 2>&1 || true
+	@docker rm $(CONTAINER_NAME) > /dev/null 2>&1 || true
+
+# Pushes the built image to the Docker registry.
+push: build
+	@echo "Pushing Docker image to registry: $(TAG)"
+	@docker push $(TAG)
+
+# Builds and pushes a multi-platform image (amd64, arm64).
+# Requires docker buildx to be set up.
+build-multiplatform:
+	@echo "Building and pushing multi-platform image: $(TAG)"
+	@docker buildx build --platform linux/amd64,linux/arm64 -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile . --push

--- a/projects/freqtrade/docker/Makefile
+++ b/projects/freqtrade/docker/Makefile
@@ -1,36 +1,27 @@
-DOCKER_ORG := noosphere
 EXAMPLE_NAME := freqtrade
-TAG := $(DOCKER_ORG)/example-$(EXAMPLE_NAME)-noosphere:latest
-
 HOST_PORT ?= 8084
 CONTAINER_PORT ?= 8084
-CONTAINER_NAME := $(EXAMPLE_NAME)
-.PHONY: build run stop test build-multiplatform try-request
 
-build:
-	@echo "Building Docker image: $(TAG)"
-	@docker build -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile .
+# Include common makefile logic
+include ../../../common.mk
 
+# Phony targets specific to this project
+.PHONY: run try-request test
+
+# Runs the container in the background (detached mode).
 run: stop build
-	@echo "Running Docker container..."
-	@docker run --rm --name $(CONTAINER_NAME) --env-file .env -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
+	@echo "Running container '$(CONTAINER_NAME)' in the background..."
+	@docker run -d --rm --name $(CONTAINER_NAME) --env-file .env -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
 
-stop:
-	@echo "Stopping and removing container '$(CONTAINER_NAME)'..."
-	@docker stop $(CONTAINER_NAME) > /dev/null 2>&1 || true
-	@docker rm $(CONTAINER_NAME) > /dev/null 2>&1 || true
-
-build-multiplatform:
-	@echo "Building and pushing multi-platform image: $(TAG)"
-	@docker buildx build --platform linux/amd64,linux/arm64 -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile . --push
-
+# Sends a test request to the running container.
 try-request:
-	@echo "Sending a test request to the running container..."
+	@echo "Sending a test request to http://localhost:$(HOST_PORT)/computation"
 	@curl -s -X POST -H "Content-Type: application/json" \
-	-d '{"pair": "BTC/USDT", "timeframe": "5m"}' \
+	-d '{"pair": "BTC/USDT", "timeframe": "15m"}' \
 	http://localhost:$(HOST_PORT)/computation
 
+# A convenience target to build, run, wait, and test all at once.
 test: run
-	@echo "Waiting for container to start..."
-	@sleep 5
+	@echo "Waiting for container and freqtrade bot to initialize..."
+	@sleep 15
 	@$(MAKE) try-request

--- a/projects/hello-world/docker/Makefile
+++ b/projects/hello-world/docker/Makefile
@@ -1,28 +1,21 @@
-DOCKER_ORG := noosphere
 EXAMPLE_NAME := hello-world
-TAG := $(DOCKER_ORG)/example-$(EXAMPLE_NAME)-noosphere:latest
-
 HOST_PORT ?= 8081
 CONTAINER_PORT ?= 8081
-.PHONY: build run build-multiplatform try-request
 
-build:
-	@echo "Building Docker image: $(TAG)"
-	@docker build -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile .
+# Include common makefile logic
+include ../../../common.mk
 
-run: build
-	@echo "Running Docker container..."
-	@docker run --rm -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
+# Phony targets specific to this project
+.PHONY: run try-request
 
-# You may need to set up a docker builder, to do so run:
-# docker buildx create --name mybuilder --bootstrap --use
-# refer to https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images for more info
-build-multiplatform:
-	@echo "Building and pushing multi-platform image: $(TAG)"
-	@docker buildx build --platform linux/amd64,linux/arm64 -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile . --push
+# Runs the container, ensuring it's stopped first.
+run: stop build
+	@echo "Running container '$(CONTAINER_NAME)'..."
+	@docker run --rm --name $(CONTAINER_NAME) -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
 
+# Sends a test request to the running container.
 try-request:
-	@echo "Sending a test request to the running container..."
-	@curl -X POST -H "Content-Type: application/json" \
+	@echo "Sending a test request to http://localhost:$(HOST_PORT)/computation"
+	@curl -s -X POST -H "Content-Type: application/json" \
 	-d '{"input": "Gemini"}' \
 	http://localhost:$(HOST_PORT)/computation

--- a/projects/llm/docker/Makefile
+++ b/projects/llm/docker/Makefile
@@ -1,38 +1,28 @@
-DOCKER_ORG := noosphere
 EXAMPLE_NAME := llm
-TAG := $(DOCKER_ORG)/example-$(EXAMPLE_NAME)-noosphere:latest
-
 HOST_PORT ?= 8082
 CONTAINER_PORT ?= 8082
-CONTAINER_NAME := $(EXAMPLE_NAME)
-.PHONY: build run stop build-multiplatform try-request try-request-openai
 
-build:
-	@echo "Building Docker image: $(TAG)"
-	@docker build -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile .
+# Include common makefile logic
+include ../../../common.mk
 
+# Phony targets specific to this project
+.PHONY: run try-request try-request-gemini
+
+# Runs the container with the .env file, ensuring it's stopped first.
 run: stop build
-	@echo "Running Docker container with .env file..."
+	@echo "Running container '$(CONTAINER_NAME)' with .env file..."
 	@docker run --rm --name $(CONTAINER_NAME) --env-file .env -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
 
-stop:
-	@echo "Stopping and removing container '$(CONTAINER_NAME)'..."
-	@docker stop $(CONTAINER_NAME) > /dev/null 2>&1 || true
-	@docker rm $(CONTAINER_NAME) > /dev/null 2>&1 || true
-# You may need to set up a docker builder, to do so run:
-# docker buildx create --name mybuilder --bootstrap --use
-# refer to https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images for more info
-build-multiplatform:
-	@echo "Building and pushing multi-platform image: $(TAG)"
-	@docker buildx build --platform linux/amd64,linux/arm64 -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile . --push
-
+# Sends a test request for a gateway-routed model.
 try-request:
-	@echo "Sending a test request to the running container..."
+	@echo "Sending a test request for an LLMRouter model..."
 	@curl -s -X POST -H "Content-Type: application/json" \
-	-d '{"model": "ollama/gpt-oss:120b", "prompt": "What is noosphere?"}' \
+	-d '{"model": "openai/gpt-4o", "prompt": "What is noosphere?"}' \
 	http://localhost:$(HOST_PORT)/computation
+
+# Sends a test request specifically for a Gemini model.
 try-request-gemini:
-	@echo "Sending a test request to the running container..."
+	@echo "Sending a test request for a Gemini model..."
 	@curl -s -X POST -H "Content-Type: application/json" \
-	-d '{"model": "gemini/gemini-2.5-pro", "prompt": "What is noosphere?"}' \
+	-d '{"model": "gemini/gemini-pro", "prompt": "What is noosphere?"}' \
 	http://localhost:$(HOST_PORT)/computation

--- a/projects/open-ai/docker/Makefile
+++ b/projects/open-ai/docker/Makefile
@@ -1,33 +1,21 @@
-DOCKER_ORG := noosphere
 EXAMPLE_NAME := open-ai
-TAG := $(DOCKER_ORG)/example-$(EXAMPLE_NAME)-noosphere:latest
-
 HOST_PORT ?= 8083
 CONTAINER_PORT ?= 8083
-CONTAINER_NAME := $(EXAMPLE_NAME)
-.PHONY: build run stop build-multiplatform try-request
 
-build:
-	@echo "Building Docker image: $(TAG)"
-	@docker build -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile .
+# Include common makefile logic
+include ../../../common.mk
 
+# Phony targets specific to this project
+.PHONY: run try-request
+
+# Runs the container with the .env file, ensuring it's stopped first.
 run: stop build
-	@echo "Running Docker container with .env file..."
+	@echo "Running container '$(CONTAINER_NAME)' with .env file..."
 	@docker run --rm --name $(CONTAINER_NAME) --env-file .env -p $(HOST_PORT):$(CONTAINER_PORT) -e APP_PORT=$(CONTAINER_PORT) $(TAG)
 
-stop:
-	@echo "Stopping and removing container '$(CONTAINER_NAME)'..."
-	@docker stop $(CONTAINER_NAME) > /dev/null 2>&1 || true
-	@docker rm $(CONTAINER_NAME) > /dev/null 2>&1 || true
-# You may need to set up a docker builder, to do so run:
-# docker buildx create --name mybuilder --bootstrap --use
-# refer to https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images for more info
-build-multiplatform:
-	@echo "Building and pushing multi-platform image: $(TAG)"
-	@docker buildx build --platform linux/amd64,linux/arm64 -t $(TAG) --build-arg index_url=$(index_url) -f Dockerfile . --push
-
+# Sends a test request to the running container.
 try-request:
-	@echo "Sending a test request to the running container..."
+	@echo "Sending a test request to http://localhost:$(HOST_PORT)/computation"
 	@curl -s -X POST -H "Content-Type: application/json" \
-	-d '{"model": "openai/gpt-4o", "prompt": "What is noosphere?"}' \
+	-d '{"model": "gpt-4o", "prompt": "What is noosphere?"}' \
 	http://localhost:$(HOST_PORT)/computation


### PR DESCRIPTION
…sistency

- Extract shared Docker logic into a common `common.mk` file.
- Simplify and standardize project-specific Makefiles by including `common.mk`.
- Improve maintainability with consistent phony targets and streamlined commands.
- Update test request payloads and enhance container run workflows.